### PR TITLE
feat(config): add VirtIO block mmio device configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,33 @@ pub struct PassThroughDeviceConfig {
     pub irq_id: usize,
 }
 
+/// A part of `AxVMConfig`, which represents the configuration of a VirtIO block device for a virtual machine.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VirtioBlkMmioDeviceConfig {
+    /// The device ID.
+    pub device_id: String,
+    /// The MMIO base address.
+    pub mmio_base: String,
+    /// The MMIO size.
+    pub mmio_size: String,
+    /// The interrupt type.
+    pub interrupt_type: String,
+    /// The interrupt number.
+    pub interrupt_number: usize,
+    /// The guest device path.
+    pub guest_device_path: String,
+    /// The backend type.
+    pub backend_type: String,
+    /// The backend path.
+    pub backend_path: String,
+    /// The image size.
+    pub size: String,
+    /// Whether the device is readonly.
+    pub readonly: bool,
+    /// The serial number.
+    pub serial: String,
+}
+
 /// The configuration structure for the guest VM base info.
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VMBaseConfig {
@@ -175,6 +202,8 @@ pub struct VMDevicesConfig {
     pub emu_devices: Vec<EmulatedDeviceConfig>,
     /// Passthrough device Information
     pub passthrough_devices: Vec<PassThroughDeviceConfig>,
+    /// VirtIO block device Information
+    pub virtio_blk_mmio: Option<Vec<VirtioBlkMmioDeviceConfig>>,
 }
 
 /// The configuration structure for the guest VM serialized from a toml file provided by user,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -38,6 +38,7 @@ pub fn get_vm_config_template(
         devices: VMDevicesConfig {
             emu_devices: vec![],
             passthrough_devices: vec![],
+            virtio_blk_mmio: None,
         },
     }
 }


### PR DESCRIPTION
Add VirtioBlkMmioDeviceConfig struct to represent VirtIO block device configuration

``` toml
[devices]
# Emu_devices.
# Name Base-Ipa Ipa_len Alloc-Irq Emu-Type EmuConfig.
emu_devices = []

# Pass-through devices.
# Name Base-Ipa Base-Pa Length Alloc-Irq.
passthrough_devices = []

[[devices.virtio_blk_mmio]]
# Virtio block device configuration.
# Device ID.
device_id = "vda"
# MMIO base address.
mmio_base = "0x0a000000"
# MMIO size.
mmio_size = "0x200"
# Interrupt type.
interrupt_type = "level"
# Interrupt number.
interrupt_number = 16
# Guest device path.
guest_device_path = "/dev/vda"
# Backend type.
backend_type = "file"
# Backend path.
backend_path = "vm_nimbos.img"
# Image size.
size = "10GB"
# Readonly.
readonly = false
# Serial.
serial = "MMIO_DISK001"
```


