### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Mingxian Su <aarkegz@gmail.com>",
 ]
 keywords = ["axvisor", "config", "toml"]
-homepage = "https://github.com/arceos-hypervisor/axvmconfig"
+repository = "https://github.com/arceos-hypervisor/axvmconfig"
 description = "A simple VM configuration tool for ArceOS-Hypervisor."
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0" # MulanPubL2 is not included in SPDX
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/104